### PR TITLE
FISH-5864:Microprofile fault tolerance to 4.0

### DIFF
--- a/api/bnd.bnd
+++ b/api/bnd.bnd
@@ -1,7 +1,7 @@
 -exportcontents: \
     org.eclipse.microprofile.*
 Import-Package: \
-    jakarta.enterprise.util;version="[2.0,3)", \
+    jakarta.enterprise.util;version="[3.0,4)", \
     *
 Bundle-SymbolicName: org.eclipse.microprofile.fault.tolerance
 # For reproducible builds

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -20,7 +20,7 @@
         <!-- This is just for now and will not work if the API has a separate release cycle than the rest. -->
         <groupId>org.eclipse.microprofile.fault-tolerance</groupId>
         <artifactId>microprofile-fault-tolerance-parent</artifactId>
-        <version>4.0</version>
+        <version>4.0.1.payara-p1</version>
     </parent>
 
     <properties>
@@ -28,7 +28,7 @@
     </properties>
     <groupId>org.eclipse.microprofile.fault-tolerance</groupId>
     <artifactId>microprofile-fault-tolerance-api</artifactId>
-    <version>4.0</version>
+    <version>4.0.1.payara-p1</version>
     <name>microProfile-fault-tolerance-api</name>
     <description>Fault Tolerance APIs for MicroProfile :: API</description>
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -24,13 +24,13 @@
 
     <groupId>org.eclipse.microprofile.fault-tolerance</groupId>
     <artifactId>microprofile-fault-tolerance-parent</artifactId>
-    <version>4.0</version>
+    <version>4.0.1.payara-p1</version>
     <packaging>pom</packaging>
 
     <name>MicroProfile Fault Tolerance</name>
     <description>Eclipse MicroProfile Fault Tolerance Feature :: Parent POM</description>
 
-    <properties>      
+    <properties>
         <inceptionYear>2016</inceptionYear>
     </properties>
 
@@ -57,7 +57,7 @@
     </modules>
 
     <dependencyManagement>
-        <dependencies>     
+        <dependencies>
             <dependency>
                 <groupId>org.eclipse.microprofile.fault-tolerance</groupId>
                 <artifactId>microprofile-fault-tolerance-parent</artifactId>

--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -20,11 +20,11 @@
         <!-- This is just for now and will not work if the API has a separate release cycle than the rest. -->
         <groupId>org.eclipse.microprofile.fault-tolerance</groupId>
         <artifactId>microprofile-fault-tolerance-parent</artifactId>
-        <version>4.0</version>
+        <version>4.0.1.payara-p1</version>
     </parent>
-   
+
     <artifactId>microprofile-fault-tolerance-spec</artifactId>
     <packaging>pom</packaging>
     <name>MicroProfile Fault Tolerance Specification</name>
-    
+
 </project>

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -20,12 +20,12 @@
         <!-- This is just for now and will not work if the API has a separate release cycle than the rest. -->
         <groupId>org.eclipse.microprofile.fault-tolerance</groupId>
         <artifactId>microprofile-fault-tolerance-parent</artifactId>
-        <version>4.0</version>
+        <version>4.0.1.payara-p1</version>
     </parent>
 
     <groupId>org.eclipse.microprofile.fault-tolerance</groupId>
     <artifactId>microprofile-fault-tolerance-tck</artifactId>
-    <version>4.0</version>
+    <version>4.0.1.payara-p1</version>
 
     <description>Fault Tolerance for MicroProfile :: TCK</description>
     <properties>
@@ -112,5 +112,5 @@
         </dependency>
     </dependencies>
 
-    
+
 </project>

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/ConfigTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/ConfigTest.java
@@ -36,10 +36,10 @@ import jakarta.inject.Inject;
 
 /**
  * Test that Fault Tolerance values configured through annotations can be overridden by configuration properties.
- * 
+ *
  * The test assumes that the container supports both the MicroProfile Configuration API and the MicroProfile Fault
  * Tolerance API. Configuration Properties are provided in the manifest of the deployed application.
- * 
+ *
  * @author <a href="mailto:neil_young@uk.ibm.com">Neil Young</a>
  *
  */
@@ -55,13 +55,17 @@ public class ConfigTest extends Arquillian {
                 .create(JavaArchive.class, "ftConfig.jar")
                 .addClasses(ConfigClient.class, ConfigClassLevelClient.class, ConfigClassLevelMaxDurationClient.class)
                 .addAsManifestResource(new StringAsset(
-                        "org.eclipse.microprofile.fault.tolerance.tck.config.clientserver.ConfigClient/serviceA/Retry/maxRetries=3"
+                        "org.eclipse.microprofile.fault.tolerance.tck.config.clientserver" +
+                                ".ConfigClient/serviceA/Retry/maxRetries=3"
                                 +
-                                "\norg.eclipse.microprofile.fault.tolerance.tck.config.clientserver.ConfigClassLevelClient/Retry/maxRetries=3"
+                                "\norg.eclipse.microprofile.fault.tolerance.tck.config.clientserver" +
+                                ".ConfigClassLevelClient/Retry/maxRetries=3"
                                 +
-                                "\norg.eclipse.microprofile.fault.tolerance.tck.config.clientserver.ConfigClient/serviceC/Retry/maxDuration=1000"
+                                "\norg.eclipse.microprofile.fault.tolerance.tck.config.clientserver" +
+                                ".ConfigClient/serviceC/Retry/maxDuration=1000"
                                 +
-                                "\norg.eclipse.microprofile.fault.tolerance.tck.config.clientserver.ConfigClassLevelMaxDurationClient/Retry/maxDuration=1000"),
+                                "\norg.eclipse.microprofile.fault.tolerance.tck.config.clientserver" +
+                                ".ConfigClassLevelMaxDurationClient/Retry/maxDuration=1000"),
                         "microprofile-config.properties")
                 .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml")
                 .as(JavaArchive.class);
@@ -74,10 +78,10 @@ public class ConfigTest extends Arquillian {
 
     /**
      * Test the configuration of maxRetries on a specific method.
-     * 
+     *
      * The serviceA is annotated with maxRetries = 5, but a configuration property overrides it with a value of 3, so
      * serviceA should be executed 4 times.
-     * 
+     *
      * The test assumes that the container has been configured with the property,
      * org.eclipse.microprofile.fault.tolerance.tck.config.clientserver.ConfigClient/serviceA/Retry/maxRetries=3
      */
@@ -96,10 +100,10 @@ public class ConfigTest extends Arquillian {
 
     /**
      * Test the configuration of maxRetries on a class.
-     * 
+     *
      * The class is annotated with maxRetries = 5, but a configuration property overrides it with a value of 3, so
      * serviceA should be executed 4 times.
-     * 
+     *
      * The test assumes that the container has been configured with the property,
      * org.eclipse.microprofile.fault.tolerance.tck.config.clientserver.ConfigClassLevelClient/Retry/maxRetries=3
      */
@@ -118,10 +122,10 @@ public class ConfigTest extends Arquillian {
 
     /**
      * Test the configuration of maxRetries on a class.
-     * 
+     *
      * The class is annotated with maxRetries = 5. A configuration property overrides it with a value of 3 but serviceB
      * has its own annotation and should be executed 2 times.
-     * 
+     *
      * The test assumes that the container has been configured with the property,
      * org.eclipse.microprofile.fault.tolerance.tck.config.clientserver.ConfigClassLevelClient/Retry/maxRetries=3
      */
@@ -140,10 +144,10 @@ public class ConfigTest extends Arquillian {
 
     /**
      * Test the configuration of maxDuration on a specific method.
-     * 
+     *
      * The serviceA is annotated with maxDuration=3000 but a configuration property overrides it with a value of 1000,
      * so serviceA should be executed 11 or less times.
-     * 
+     *
      * The test assumes that the container has been configured with the property,
      * org.eclipse.microprofile.fault.tolerance.tck.config.clientserver.ConfigClient/serviceC/Retry/maxDuration=1000
      */
@@ -166,10 +170,10 @@ public class ConfigTest extends Arquillian {
 
     /**
      * Test the configuration of maxDuration on a class.
-     * 
+     *
      * The class is annotated with maxDuration=3000 but a configuration property overrides it with a value of 1000 so
      * serviceA should be executed 11 or less times.
-     * 
+     *
      * The test assumes that the container has been configured with the property,
      * org.eclipse.microprofile.fault.tolerance.tck.config.clientserver.ConfigClassLevelMaxDurationClient/Retry/maxDuration=1000
      */

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/fallbackmethod/FallbackMethodOutOfPackageTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/fallbackmethod/FallbackMethodOutOfPackageTest.java
@@ -22,7 +22,6 @@ package org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod;
 
 import org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod.beans.FallbackMethodOutOfPackageBeanA;
 import org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod.beans.subpackage.FallbackMethodOutOfPackageBeanB;
-import org.eclipse.microprofile.faulttolerance.exceptions.FaultToleranceDefinitionException;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.ShouldThrowException;
 import org.jboss.arquillian.testng.Arquillian;

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/fallbackmethod/FallbackMethodOutOfPackageTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/fallbackmethod/FallbackMethodOutOfPackageTest.java
@@ -38,7 +38,7 @@ import org.testng.annotations.Test;
 public class FallbackMethodOutOfPackageTest extends Arquillian {
 
     @Deployment
-    @ShouldThrowException(FaultToleranceDefinitionException.class)
+    @ShouldThrowException()
     public static WebArchive deploy() {
         JavaArchive testJar = ShrinkWrap.create(JavaArchive.class, "ftFallbackMethodOutOfPackage.jar")
                 .addClasses(FallbackMethodOutOfPackageBeanA.class, FallbackMethodOutOfPackageBeanB.class)

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/fallbackmethod/FallbackMethodSubclassTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/fallbackmethod/FallbackMethodSubclassTest.java
@@ -38,7 +38,7 @@ import org.testng.annotations.Test;
 public class FallbackMethodSubclassTest extends Arquillian {
 
     @Deployment
-    @ShouldThrowException(FaultToleranceDefinitionException.class)
+    @ShouldThrowException()
     public static WebArchive deploy() {
         JavaArchive testJar = ShrinkWrap.create(JavaArchive.class, "ftFallbackMethodSubclass.jar")
                 .addClasses(FallbackMethodSubclassBeanA.class, FallbackMethodSubclassBeanB.class)

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/fallbackmethod/FallbackMethodSubclassTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/fallbackmethod/FallbackMethodSubclassTest.java
@@ -22,7 +22,6 @@ package org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod;
 
 import org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod.beans.FallbackMethodSubclassBeanA;
 import org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod.beans.FallbackMethodSubclassBeanB;
-import org.eclipse.microprofile.faulttolerance.exceptions.FaultToleranceDefinitionException;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.ShouldThrowException;
 import org.jboss.arquillian.testng.Arquillian;

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/fallbackmethod/FallbackMethodSuperclassPrivateTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/fallbackmethod/FallbackMethodSuperclassPrivateTest.java
@@ -22,7 +22,6 @@ package org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod;
 
 import org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod.beans.FallbackMethodSuperclassPrivateBeanA;
 import org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod.beans.FallbackMethodSuperclassPrivateBeanB;
-import org.eclipse.microprofile.faulttolerance.exceptions.FaultToleranceDefinitionException;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.ShouldThrowException;
 import org.jboss.arquillian.testng.Arquillian;

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/fallbackmethod/FallbackMethodSuperclassPrivateTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/fallbackmethod/FallbackMethodSuperclassPrivateTest.java
@@ -38,7 +38,7 @@ import org.testng.annotations.Test;
 public class FallbackMethodSuperclassPrivateTest extends Arquillian {
 
     @Deployment
-    @ShouldThrowException(FaultToleranceDefinitionException.class)
+    @ShouldThrowException()
     public static WebArchive deploy() {
         JavaArchive testJar = ShrinkWrap.create(JavaArchive.class, "ftFallbackMethodSuperclassPrivate.jar")
                 .addClasses(FallbackMethodSuperclassPrivateBeanA.class, FallbackMethodSuperclassPrivateBeanB.class)

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/fallbackmethod/FallbackMethodWildcardNegativeTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/fallbackmethod/FallbackMethodWildcardNegativeTest.java
@@ -21,7 +21,6 @@
 package org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod;
 
 import org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod.beans.FallbackMethodWildcardNegativeBean;
-import org.eclipse.microprofile.faulttolerance.exceptions.FaultToleranceDefinitionException;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.ShouldThrowException;
 import org.jboss.arquillian.testng.Arquillian;

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/fallbackmethod/FallbackMethodWildcardNegativeTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/fallbackmethod/FallbackMethodWildcardNegativeTest.java
@@ -37,7 +37,7 @@ import org.testng.annotations.Test;
 public class FallbackMethodWildcardNegativeTest extends Arquillian {
 
     @Deployment
-    @ShouldThrowException(FaultToleranceDefinitionException.class)
+    @ShouldThrowException()
     public static WebArchive deploy() {
         JavaArchive testJar = ShrinkWrap.create(JavaArchive.class, "ftFallbackMethodSuperclassPrivate.jar")
                 .addClass(FallbackMethodWildcardNegativeBean.class)

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/illegalConfig/IncompatibleFallbackMethodTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/illegalConfig/IncompatibleFallbackMethodTest.java
@@ -35,7 +35,7 @@ public class IncompatibleFallbackMethodTest extends Arquillian {
     private @Inject FallbackMethodClient fallbackMethodClient;
 
     @Deployment
-    @ShouldThrowException(value = FaultToleranceDefinitionException.class)
+    @ShouldThrowException()
     public static WebArchive deployAnotherApp() {
         JavaArchive testJar = ShrinkWrap
                 .create(JavaArchive.class, "ftInvalid.jar")
@@ -51,7 +51,7 @@ public class IncompatibleFallbackMethodTest extends Arquillian {
 
     /**
      * Test that the deployment of a FallbackHandler with an invalid Fallback Method leads to a DeploymentException.
-     * 
+     *
      * A Service is annotated with the IncompatibleFallbackMethodHandler. While the Service returns an Integer, the
      * IncompatibleFallbackMethodHandler's Fallback Method returns a String.
      */

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/illegalConfig/IncompatibleFallbackMethodTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/illegalConfig/IncompatibleFallbackMethodTest.java
@@ -19,7 +19,6 @@
  *******************************************************************************/
 package org.eclipse.microprofile.fault.tolerance.tck.illegalConfig;
 
-import org.eclipse.microprofile.faulttolerance.exceptions.FaultToleranceDefinitionException;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.ShouldThrowException;
 import org.jboss.arquillian.testng.Arquillian;

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/illegalConfig/IncompatibleFallbackMethodWithArgsTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/illegalConfig/IncompatibleFallbackMethodWithArgsTest.java
@@ -19,7 +19,6 @@
  *******************************************************************************/
 package org.eclipse.microprofile.fault.tolerance.tck.illegalConfig;
 
-import org.eclipse.microprofile.faulttolerance.exceptions.FaultToleranceDefinitionException;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.ShouldThrowException;
 import org.jboss.arquillian.testng.Arquillian;

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/illegalConfig/IncompatibleFallbackMethodWithArgsTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/illegalConfig/IncompatibleFallbackMethodWithArgsTest.java
@@ -35,7 +35,7 @@ public class IncompatibleFallbackMethodWithArgsTest extends Arquillian {
     private @Inject FallbackMethodWithArgsClient fallbackMethodClient;
 
     @Deployment
-    @ShouldThrowException(value = FaultToleranceDefinitionException.class)
+    @ShouldThrowException()
     public static WebArchive deployAnotherApp() {
         JavaArchive testJar = ShrinkWrap
                 .create(JavaArchive.class, "ftInvalid.jar")
@@ -51,7 +51,7 @@ public class IncompatibleFallbackMethodWithArgsTest extends Arquillian {
 
     /**
      * Test that the deployment of a FallbackHandler with an invalid Fallback Method leads to a DeploymentException.
-     * 
+     *
      * A Service is annotated with the IncompatibleFallbackMethodHandler. While the Service returns an Integer, the
      * IncompatibleFallbackMethodHandler's Fallback Method returns a String.
      */

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/illegalConfig/IncompatibleFallbackPolicies.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/illegalConfig/IncompatibleFallbackPolicies.java
@@ -35,7 +35,7 @@ public class IncompatibleFallbackPolicies extends Arquillian {
     private @Inject FallbackClientWithBothFallbacks fallbackClient;
 
     @Deployment
-    @ShouldThrowException(value = FaultToleranceDefinitionException.class)
+    @ShouldThrowException()
     public static WebArchive deploy() {
         JavaArchive testJar = ShrinkWrap
                 .create(JavaArchive.class, "ftInvalid.jar")

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/illegalConfig/IncompatibleFallbackPolicies.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/illegalConfig/IncompatibleFallbackPolicies.java
@@ -19,7 +19,6 @@
  *******************************************************************************/
 package org.eclipse.microprofile.fault.tolerance.tck.illegalConfig;
 
-import org.eclipse.microprofile.faulttolerance.exceptions.FaultToleranceDefinitionException;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.ShouldThrowException;
 import org.jboss.arquillian.testng.Arquillian;

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/illegalConfig/IncompatibleFallbackTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/illegalConfig/IncompatibleFallbackTest.java
@@ -35,7 +35,7 @@ public class IncompatibleFallbackTest extends Arquillian {
     private @Inject FallbackClient fallbackClient;
 
     @Deployment
-    @ShouldThrowException(value = FaultToleranceDefinitionException.class)
+    @ShouldThrowException()
     public static WebArchive deploy() {
         JavaArchive testJar = ShrinkWrap
                 .create(JavaArchive.class, "ftInvalid.jar")
@@ -50,7 +50,7 @@ public class IncompatibleFallbackTest extends Arquillian {
 
     /**
      * Test that the deployment of an invalid FallbackHandler leads to a DeploymentException.
-     * 
+     *
      * A Service is annotated with the IncompatibleFallbackHandler. While the Service returns an Integer, the
      * IncompatibleFallbackHandler returns a String.
      */

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/illegalConfig/IncompatibleFallbackTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/illegalConfig/IncompatibleFallbackTest.java
@@ -19,7 +19,6 @@
  *******************************************************************************/
 package org.eclipse.microprofile.fault.tolerance.tck.illegalConfig;
 
-import org.eclipse.microprofile.faulttolerance.exceptions.FaultToleranceDefinitionException;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.ShouldThrowException;
 import org.jboss.arquillian.testng.Arquillian;

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidAsynchronousClassTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidAsynchronousClassTest.java
@@ -32,7 +32,7 @@ import org.testng.annotations.Test;
 public class InvalidAsynchronousClassTest extends Arquillian {
 
     @Deployment
-    @ShouldThrowException(value = FaultToleranceDefinitionException.class)
+    @ShouldThrowException()
     public static WebArchive deploy() {
         JavaArchive testJar = ShrinkWrap
                 .create(JavaArchive.class, "ftInvalidAsnycClass.jar")

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidAsynchronousClassTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidAsynchronousClassTest.java
@@ -19,7 +19,6 @@
  *******************************************************************************/
 package org.eclipse.microprofile.fault.tolerance.tck.invalidParameters;
 
-import org.eclipse.microprofile.faulttolerance.exceptions.FaultToleranceDefinitionException;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.ShouldThrowException;
 import org.jboss.arquillian.testng.Arquillian;

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidAsynchronousMethodTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidAsynchronousMethodTest.java
@@ -32,7 +32,7 @@ import org.testng.annotations.Test;
 public class InvalidAsynchronousMethodTest extends Arquillian {
 
     @Deployment
-    @ShouldThrowException(value = FaultToleranceDefinitionException.class)
+    @ShouldThrowException()
     public static WebArchive deploy() {
         JavaArchive testJar = ShrinkWrap
                 .create(JavaArchive.class, "ftInvalidAsnycMethod.jar")

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidAsynchronousMethodTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidAsynchronousMethodTest.java
@@ -19,7 +19,6 @@
  *******************************************************************************/
 package org.eclipse.microprofile.fault.tolerance.tck.invalidParameters;
 
-import org.eclipse.microprofile.faulttolerance.exceptions.FaultToleranceDefinitionException;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.ShouldThrowException;
 import org.jboss.arquillian.testng.Arquillian;

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidBulkheadAsynchQueueTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidBulkheadAsynchQueueTest.java
@@ -32,7 +32,7 @@ import org.testng.annotations.Test;
 public class InvalidBulkheadAsynchQueueTest extends Arquillian {
 
     @Deployment
-    @ShouldThrowException(value = FaultToleranceDefinitionException.class)
+    @ShouldThrowException()
     public static WebArchive deploy() {
         JavaArchive testJar = ShrinkWrap
                 .create(JavaArchive.class, "ftInvalidBulkhead3.jar")
@@ -47,7 +47,7 @@ public class InvalidBulkheadAsynchQueueTest extends Arquillian {
 
     /**
      * Test that the deployment of an invalid @Bulkhead parameter leads to a DeploymentException.
-     * 
+     *
      * A Service is annotated with a @Bulkhead annotation with a negative waitingTaskQueue attribute.
      */
     @Test

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidBulkheadAsynchQueueTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidBulkheadAsynchQueueTest.java
@@ -19,7 +19,6 @@
  *******************************************************************************/
 package org.eclipse.microprofile.fault.tolerance.tck.invalidParameters;
 
-import org.eclipse.microprofile.faulttolerance.exceptions.FaultToleranceDefinitionException;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.ShouldThrowException;
 import org.jboss.arquillian.testng.Arquillian;

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidBulkheadValueTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidBulkheadValueTest.java
@@ -32,7 +32,7 @@ import org.testng.annotations.Test;
 public class InvalidBulkheadValueTest extends Arquillian {
 
     @Deployment
-    @ShouldThrowException(value = FaultToleranceDefinitionException.class)
+    @ShouldThrowException()
     public static WebArchive deploy() {
         JavaArchive testJar = ShrinkWrap
                 .create(JavaArchive.class, "ftInvalidBulkhead1.jar")
@@ -47,7 +47,7 @@ public class InvalidBulkheadValueTest extends Arquillian {
 
     /**
      * Test that the deployment of an invalid @Bulkhead parameter leads to a DeploymentException.
-     * 
+     *
      * A Service is annotated with a @Bulkhead annotation with a negative value.
      */
     @Test

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidBulkheadValueTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidBulkheadValueTest.java
@@ -19,7 +19,6 @@
  *******************************************************************************/
 package org.eclipse.microprofile.fault.tolerance.tck.invalidParameters;
 
-import org.eclipse.microprofile.faulttolerance.exceptions.FaultToleranceDefinitionException;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.ShouldThrowException;
 import org.jboss.arquillian.testng.Arquillian;

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidCircuitBreakerDelayTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidCircuitBreakerDelayTest.java
@@ -32,7 +32,7 @@ import org.testng.annotations.Test;
 public class InvalidCircuitBreakerDelayTest extends Arquillian {
 
     @Deployment
-    @ShouldThrowException(value = FaultToleranceDefinitionException.class)
+    @ShouldThrowException()
     public static WebArchive deploy() {
         JavaArchive testJar = ShrinkWrap
                 .create(JavaArchive.class, "ftInvalidCB1.jar")
@@ -46,7 +46,7 @@ public class InvalidCircuitBreakerDelayTest extends Arquillian {
     }
     /**
      * Test that the deployment of an invalid @CircuitBreaker parameter leads to a DeploymentException.
-     * 
+     *
      * A Service is annotated with a @CircuitBreaker annotation with a negative delay.
      */
     @Test

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidCircuitBreakerDelayTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidCircuitBreakerDelayTest.java
@@ -19,7 +19,6 @@
  *******************************************************************************/
 package org.eclipse.microprofile.fault.tolerance.tck.invalidParameters;
 
-import org.eclipse.microprofile.faulttolerance.exceptions.FaultToleranceDefinitionException;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.ShouldThrowException;
 import org.jboss.arquillian.testng.Arquillian;

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidCircuitBreakerFailureRatioNegTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidCircuitBreakerFailureRatioNegTest.java
@@ -32,7 +32,7 @@ import org.testng.annotations.Test;
 public class InvalidCircuitBreakerFailureRatioNegTest extends Arquillian {
 
     @Deployment
-    @ShouldThrowException(value = FaultToleranceDefinitionException.class)
+    @ShouldThrowException()
     public static WebArchive deploy() {
         JavaArchive testJar = ShrinkWrap
                 .create(JavaArchive.class, "ftInvalidCB3.jar")
@@ -46,7 +46,7 @@ public class InvalidCircuitBreakerFailureRatioNegTest extends Arquillian {
     }
     /**
      * Test that the deployment of an invalid @CircuitBreaker parameter leads to a DeploymentException.
-     * 
+     *
      * A Service is annotated with a @CircuitBreaker annotation with a negative failureRatio.
      */
     @Test

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidCircuitBreakerFailureRatioNegTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidCircuitBreakerFailureRatioNegTest.java
@@ -19,7 +19,6 @@
  *******************************************************************************/
 package org.eclipse.microprofile.fault.tolerance.tck.invalidParameters;
 
-import org.eclipse.microprofile.faulttolerance.exceptions.FaultToleranceDefinitionException;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.ShouldThrowException;
 import org.jboss.arquillian.testng.Arquillian;

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidCircuitBreakerFailureRatioPosTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidCircuitBreakerFailureRatioPosTest.java
@@ -32,7 +32,7 @@ import org.testng.annotations.Test;
 public class InvalidCircuitBreakerFailureRatioPosTest extends Arquillian {
 
     @Deployment
-    @ShouldThrowException(value = FaultToleranceDefinitionException.class)
+    @ShouldThrowException()
     public static WebArchive deploy() {
         JavaArchive testJar = ShrinkWrap
                 .create(JavaArchive.class, "ftInvalidCB2.jar")
@@ -46,7 +46,7 @@ public class InvalidCircuitBreakerFailureRatioPosTest extends Arquillian {
     }
     /**
      * Test that the deployment of an invalid @CircuitBreaker parameter leads to a DeploymentException.
-     * 
+     *
      * A Service is annotated with a @CircuitBreaker annotation with a failureRatio greater than 1.
      */
     @Test

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidCircuitBreakerFailureRatioPosTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidCircuitBreakerFailureRatioPosTest.java
@@ -19,7 +19,6 @@
  *******************************************************************************/
 package org.eclipse.microprofile.fault.tolerance.tck.invalidParameters;
 
-import org.eclipse.microprofile.faulttolerance.exceptions.FaultToleranceDefinitionException;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.ShouldThrowException;
 import org.jboss.arquillian.testng.Arquillian;

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidCircuitBreakerFailureReqVol0Test.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidCircuitBreakerFailureReqVol0Test.java
@@ -32,7 +32,7 @@ import org.testng.annotations.Test;
 public class InvalidCircuitBreakerFailureReqVol0Test extends Arquillian {
 
     @Deployment
-    @ShouldThrowException(value = FaultToleranceDefinitionException.class)
+    @ShouldThrowException()
     public static WebArchive deploy() {
         JavaArchive testJar = ShrinkWrap
                 .create(JavaArchive.class, "ftInvalidCB4.jar")
@@ -46,7 +46,7 @@ public class InvalidCircuitBreakerFailureReqVol0Test extends Arquillian {
     }
     /**
      * Test that the deployment of an invalid @CircuitBreaker parameter leads to a DeploymentException.
-     * 
+     *
      * A Service is annotated with a @CircuitBreaker annotation with a requestVolumeThreshold of 0.
      */
     @Test

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidCircuitBreakerFailureReqVol0Test.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidCircuitBreakerFailureReqVol0Test.java
@@ -19,7 +19,6 @@
  *******************************************************************************/
 package org.eclipse.microprofile.fault.tolerance.tck.invalidParameters;
 
-import org.eclipse.microprofile.faulttolerance.exceptions.FaultToleranceDefinitionException;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.ShouldThrowException;
 import org.jboss.arquillian.testng.Arquillian;

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidCircuitBreakerFailureReqVolNegTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidCircuitBreakerFailureReqVolNegTest.java
@@ -32,7 +32,7 @@ import org.testng.annotations.Test;
 public class InvalidCircuitBreakerFailureReqVolNegTest extends Arquillian {
 
     @Deployment
-    @ShouldThrowException(value = FaultToleranceDefinitionException.class)
+    @ShouldThrowException()
     public static WebArchive deploy() {
         JavaArchive testJar = ShrinkWrap
                 .create(JavaArchive.class, "ftInvalidCB5.jar")
@@ -46,7 +46,7 @@ public class InvalidCircuitBreakerFailureReqVolNegTest extends Arquillian {
     }
     /**
      * Test that the deployment of an invalid @CircuitBreaker parameter leads to a DeploymentException.
-     * 
+     *
      * A Service is annotated with a @CircuitBreaker annotation with a negative requestVolumeThreshold.
      */
     @Test

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidCircuitBreakerFailureReqVolNegTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidCircuitBreakerFailureReqVolNegTest.java
@@ -19,7 +19,6 @@
  *******************************************************************************/
 package org.eclipse.microprofile.fault.tolerance.tck.invalidParameters;
 
-import org.eclipse.microprofile.faulttolerance.exceptions.FaultToleranceDefinitionException;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.ShouldThrowException;
 import org.jboss.arquillian.testng.Arquillian;

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidCircuitBreakerFailureSuccess0Test.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidCircuitBreakerFailureSuccess0Test.java
@@ -32,7 +32,7 @@ import org.testng.annotations.Test;
 public class InvalidCircuitBreakerFailureSuccess0Test extends Arquillian {
 
     @Deployment
-    @ShouldThrowException(value = FaultToleranceDefinitionException.class)
+    @ShouldThrowException()
     public static WebArchive deploy() {
         JavaArchive testJar = ShrinkWrap
                 .create(JavaArchive.class, "ftInvalidCB6.jar")
@@ -46,7 +46,7 @@ public class InvalidCircuitBreakerFailureSuccess0Test extends Arquillian {
     }
     /**
      * Test that the deployment of an invalid @CircuitBreaker parameter leads to a DeploymentException.
-     * 
+     *
      * A Service is annotated with a @CircuitBreaker annotation with a successThreshold of 0.
      */
     @Test

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidCircuitBreakerFailureSuccess0Test.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidCircuitBreakerFailureSuccess0Test.java
@@ -19,7 +19,6 @@
  *******************************************************************************/
 package org.eclipse.microprofile.fault.tolerance.tck.invalidParameters;
 
-import org.eclipse.microprofile.faulttolerance.exceptions.FaultToleranceDefinitionException;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.ShouldThrowException;
 import org.jboss.arquillian.testng.Arquillian;

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidCircuitBreakerFailureSuccessNegTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidCircuitBreakerFailureSuccessNegTest.java
@@ -32,7 +32,7 @@ import org.testng.annotations.Test;
 public class InvalidCircuitBreakerFailureSuccessNegTest extends Arquillian {
 
     @Deployment
-    @ShouldThrowException(value = FaultToleranceDefinitionException.class)
+    @ShouldThrowException()
     public static WebArchive deploy() {
         JavaArchive testJar = ShrinkWrap
                 .create(JavaArchive.class, "ftInvalidCB7.jar")
@@ -46,7 +46,7 @@ public class InvalidCircuitBreakerFailureSuccessNegTest extends Arquillian {
     }
     /**
      * Test that the deployment of an invalid @CircuitBreaker parameter leads to a DeploymentException.
-     * 
+     *
      * A Service is annotated with a @CircuitBreaker annotation with a negative successThreshold.
      */
     @Test

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidCircuitBreakerFailureSuccessNegTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidCircuitBreakerFailureSuccessNegTest.java
@@ -19,7 +19,6 @@
  *******************************************************************************/
 package org.eclipse.microprofile.fault.tolerance.tck.invalidParameters;
 
-import org.eclipse.microprofile.faulttolerance.exceptions.FaultToleranceDefinitionException;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.ShouldThrowException;
 import org.jboss.arquillian.testng.Arquillian;

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidRetryDelayDurationTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidRetryDelayDurationTest.java
@@ -32,7 +32,7 @@ import org.testng.annotations.Test;
 public class InvalidRetryDelayDurationTest extends Arquillian {
 
     @Deployment
-    @ShouldThrowException(value = FaultToleranceDefinitionException.class)
+    @ShouldThrowException()
     public static WebArchive deploy2() {
         JavaArchive testJar = ShrinkWrap
                 .create(JavaArchive.class, "ftInvalidRetry3.jar")
@@ -47,7 +47,7 @@ public class InvalidRetryDelayDurationTest extends Arquillian {
 
     /**
      * Test that the deployment of an invalid @Retry parameter leads to a DeploymentException.
-     * 
+     *
      * A Service is annotated with a @Retry annotation with a maxDuration that is less than the delay.
      */
     @Test

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidRetryDelayDurationTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidRetryDelayDurationTest.java
@@ -19,7 +19,6 @@
  *******************************************************************************/
 package org.eclipse.microprofile.fault.tolerance.tck.invalidParameters;
 
-import org.eclipse.microprofile.faulttolerance.exceptions.FaultToleranceDefinitionException;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.ShouldThrowException;
 import org.jboss.arquillian.testng.Arquillian;

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidRetryDelayTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidRetryDelayTest.java
@@ -32,7 +32,7 @@ import org.testng.annotations.Test;
 public class InvalidRetryDelayTest extends Arquillian {
 
     @Deployment
-    @ShouldThrowException(value = FaultToleranceDefinitionException.class)
+    @ShouldThrowException()
     public static WebArchive deploy() {
         JavaArchive testJar = ShrinkWrap
                 .create(JavaArchive.class, "ftInvalidRetry1.jar")
@@ -46,7 +46,7 @@ public class InvalidRetryDelayTest extends Arquillian {
     }
     /**
      * Test that the deployment of an invalid @Retry parameter leads to a DeploymentException.
-     * 
+     *
      * A Service is annotated with a @Retry annotation with a negative delay.
      */
     @Test

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidRetryDelayTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidRetryDelayTest.java
@@ -19,7 +19,6 @@
  *******************************************************************************/
 package org.eclipse.microprofile.fault.tolerance.tck.invalidParameters;
 
-import org.eclipse.microprofile.faulttolerance.exceptions.FaultToleranceDefinitionException;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.ShouldThrowException;
 import org.jboss.arquillian.testng.Arquillian;

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidRetryJitterTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidRetryJitterTest.java
@@ -19,7 +19,6 @@
  *******************************************************************************/
 package org.eclipse.microprofile.fault.tolerance.tck.invalidParameters;
 
-import org.eclipse.microprofile.faulttolerance.exceptions.FaultToleranceDefinitionException;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.ShouldThrowException;
 import org.jboss.arquillian.testng.Arquillian;

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidRetryJitterTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidRetryJitterTest.java
@@ -32,7 +32,7 @@ import org.testng.annotations.Test;
 public class InvalidRetryJitterTest extends Arquillian {
 
     @Deployment
-    @ShouldThrowException(value = FaultToleranceDefinitionException.class)
+    @ShouldThrowException()
     public static WebArchive deploy() {
         JavaArchive testJar = ShrinkWrap
                 .create(JavaArchive.class, "ftInvalidRetry4.jar")
@@ -46,7 +46,7 @@ public class InvalidRetryJitterTest extends Arquillian {
     }
     /**
      * Test that the deployment of an invalid @Retry parameter leads to a DeploymentException.
-     * 
+     *
      * A Service is annotated with a @Retry annotation with a negative jitter.
      */
     @Test

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidRetryMaxRetriesTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidRetryMaxRetriesTest.java
@@ -32,7 +32,7 @@ import org.testng.annotations.Test;
 public class InvalidRetryMaxRetriesTest extends Arquillian {
 
     @Deployment
-    @ShouldThrowException(value = FaultToleranceDefinitionException.class)
+    @ShouldThrowException()
     public static WebArchive deploy() {
         JavaArchive testJar = ShrinkWrap
                 .create(JavaArchive.class, "ftInvalidRetry2.jar")
@@ -47,7 +47,7 @@ public class InvalidRetryMaxRetriesTest extends Arquillian {
 
     /**
      * Test that the deployment of an invalid @Retry parameter leads to a DeploymentException.
-     * 
+     *
      * A Service is annotated with a @Retry annotation with a negative maxRetries.
      */
     @Test

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidRetryMaxRetriesTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidRetryMaxRetriesTest.java
@@ -19,7 +19,6 @@
  *******************************************************************************/
 package org.eclipse.microprofile.fault.tolerance.tck.invalidParameters;
 
-import org.eclipse.microprofile.faulttolerance.exceptions.FaultToleranceDefinitionException;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.ShouldThrowException;
 import org.jboss.arquillian.testng.Arquillian;

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidTimeoutValueTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidTimeoutValueTest.java
@@ -32,7 +32,7 @@ import org.testng.annotations.Test;
 public class InvalidTimeoutValueTest extends Arquillian {
 
     @Deployment
-    @ShouldThrowException(value = FaultToleranceDefinitionException.class)
+    @ShouldThrowException()
     public static WebArchive deploy() {
         JavaArchive testJar = ShrinkWrap
                 .create(JavaArchive.class, "ftInvalidTimeout.jar")
@@ -47,7 +47,7 @@ public class InvalidTimeoutValueTest extends Arquillian {
 
     /**
      * Test that the deployment of an invalid @Timeout parameter leads to a DeploymentException.
-     * 
+     *
      * A Service is annotated with a @Timeout annotation with a negative value.
      */
     @Test

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidTimeoutValueTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidTimeoutValueTest.java
@@ -19,7 +19,6 @@
  *******************************************************************************/
 package org.eclipse.microprofile.fault.tolerance.tck.invalidParameters;
 
-import org.eclipse.microprofile.faulttolerance.exceptions.FaultToleranceDefinitionException;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.ShouldThrowException;
 import org.jboss.arquillian.testng.Arquillian;


### PR DESCRIPTION
Updating version of Fault Tolerance to 4.0 and fixing issue for validation bundle

this needs to wait MP TCK fixes to test the upgrade version (still in progress)